### PR TITLE
fix: DATA_FOLDER path update

### DIFF
--- a/.env
+++ b/.env
@@ -1,6 +1,6 @@
 # Path where you created folders earlier. 
 # Change this if you didn't create them in the repo checked out in the root directory.
-DATA_FOLDER=/root/n8n-digital-ocean
+DATA_FOLDER=/root/n8n-docker-caddy
 
 # The top level domain to serve from, this should be the same as the subdomain you created above
 DOMAIN_NAME=example.com


### PR DESCRIPTION
Reason for this commit:
Since the repository url is updated and cloning the repo by command from docs page names the repo as n8n-digital-ocean, this DATA_FOLDER path needs to be updated as well.

I've tested this myself by deploying an n8n instance from scratch and I had to either take extra step to rename the cloned repo or by editing the DATA_FOLDER path. Which is why I think its better to update this so the users don't have to take this extra step.

