### PR TITLE
fix: do not publicly expose n8n

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,8 +15,6 @@ services:
   n8n:
     image: docker.n8n.io/n8nio/n8n
     restart: always
-    ports:
-      - 5678:5678
     environment:
       - N8N_HOST=${SUBDOMAIN}.${DOMAIN_NAME}
       - N8N_PORT=5678


### PR DESCRIPTION
it is already exposed by Caddy [using the internal Docker network](https://github.com/n8n-io/n8n-docker-caddy/blob/main/caddy_config/Caddyfile#L2)